### PR TITLE
feat: add homepage layout

### DIFF
--- a/lovecanberra-frontend/src/pages/homepage/Homepage.tsx
+++ b/lovecanberra-frontend/src/pages/homepage/Homepage.tsx
@@ -1,36 +1,112 @@
-import './homepage.css'
+import './homepage.css';
+import titleImage from '../../assets/react.svg';
+
+interface Event {
+    name: string;
+    details: string;
+}
+
+interface DayPlan {
+    day: string;
+    date: string;
+    events: Event[];
+}
+
+const week: DayPlan[] = [
+    {
+        day: 'Sat',
+        date: 'Oct 26',
+        events: [
+            { name: 'Opening Gathering', details: 'Kick-off meeting at 9 AM' },
+            { name: 'City Tour', details: 'Explore Canberra landmarks' }
+        ],
+    },
+    {
+        day: 'Sun',
+        date: 'Oct 27',
+        events: [
+            { name: 'Workshop', details: 'Morning workshop on community building' },
+            { name: 'Picnic', details: 'Afternoon picnic in the park' }
+        ],
+    },
+    {
+        day: 'Mon',
+        date: 'Oct 28',
+        events: [
+            { name: 'Networking Lunch', details: 'Meet local leaders at noon' }
+        ],
+    },
+    {
+        day: 'Tue',
+        date: 'Oct 29',
+        events: [
+            { name: 'Volunteer Day', details: 'Community service projects all day' }
+        ],
+    },
+    {
+        day: 'Wed',
+        date: 'Oct 30',
+        events: [
+            { name: 'Free Day', details: 'Explore the city on your own' }
+        ],
+    },
+    {
+        day: 'Thu',
+        date: 'Oct 31',
+        events: [
+            { name: 'Halloween Party', details: 'Costume party at 7 PM' }
+        ],
+    },
+    {
+        day: 'Fri',
+        date: 'Nov 1',
+        events: [
+            { name: 'Closing Ceremony', details: 'Wrap-up event and dinner' }
+        ],
+    },
+    {
+        day: 'Sat',
+        date: 'Nov 2',
+        events: [
+            { name: 'Departure', details: 'Farewell breakfast and goodbyes' }
+        ],
+    },
+];
 
 export default function Homepage() {
     return (
-        <></>
+        <>
+            <Navbar />
+            <main className="home-main">
+                <img src={titleImage} alt="title" className="title-image" />
+                <h2 className="subheading">Weekly Plan</h2>
+                <div className="week-container">
+                    {week.map(({ day, date, events }) => (
+                        <div className="day" key={date}>
+                            <h3>{`${day} ${date}`}</h3>
+                            {events.map((event, index) => (
+                                <div className="event" key={index}>
+                                    <span className="event-name">{event.name}</span>
+                                    <div className="event-details">{event.details}</div>
+                                </div>
+                            ))}
+                        </div>
+                    ))}
+                </div>
+            </main>
+        </>
     );
 }
 
-function Day(dayOfTheWeek: string, ...events: Event[]) {
-    return(
-        <>
-            <h1>{dayOfTheWeek}</h1>
-            
-
-        </>
-    )
+function Navbar() {
+    return (
+        <nav className="navbar">
+            <div className="nav-center">october 26 - november 2</div>
+            <div className="nav-links">
+                <a href="#vision">vision</a>
+                <a href="#invite">invite</a>
+                <a href="#register">register</a>
+            </div>
+        </nav>
+    );
 }
-
-function Event() {
-
-}
-
-
-
-function Week() {
-
-}
-
-function Title() {
-
-}
-
-function MainContent() {
-
-}
-

--- a/lovecanberra-frontend/src/pages/homepage/homepage.css
+++ b/lovecanberra-frontend/src/pages/homepage/homepage.css
@@ -1,0 +1,69 @@
+.navbar {
+    position: relative;
+    padding: 1rem;
+    border-bottom: 1px solid #ccc;
+}
+
+.nav-center {
+    width: 100%;
+    text-align: center;
+    font-weight: bold;
+}
+
+.nav-links {
+    position: absolute;
+    right: 1rem;
+    top: 50%;
+    transform: translateY(-50%);
+    display: flex;
+    gap: 1rem;
+}
+
+.title-image {
+    display: block;
+    margin: 2rem auto 1rem auto;
+    max-width: 200px;
+}
+
+.subheading {
+    text-align: center;
+    margin-bottom: 2rem;
+}
+
+.week-container {
+    display: flex;
+    gap: 1rem;
+    justify-content: center;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    padding-bottom: 1rem;
+}
+
+.day {
+    border: 1px solid #ccc;
+    padding: 1rem;
+    min-width: 150px;
+}
+
+.event {
+    position: relative;
+    margin: 0.5rem 0;
+    cursor: pointer;
+}
+
+.event-details {
+    display: none;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    background: white;
+    border: 1px solid #ccc;
+    padding: 0.5rem;
+    white-space: nowrap;
+    z-index: 1;
+}
+
+.event:hover .event-details {
+    display: block;
+}
+


### PR DESCRIPTION
## Summary
- build navigation bar with centered date range and right-aligned links
- display title image and subheading
- show week schedule in a flex container with hoverable event details

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68986ce59734832482c91f336713004a