### PR TITLE
Use native tooltip for event details

### DIFF
--- a/lovecanberra-frontend/src/pages/homepage/Homepage.tsx
+++ b/lovecanberra-frontend/src/pages/homepage/Homepage.tsx
@@ -85,9 +85,8 @@ export default function Homepage() {
                         <div className="day" key={date}>
                             <h3>{`${day} ${date}`}</h3>
                             {events.map((event, index) => (
-                                <div className="event" key={index}>
+                                <div className="event" key={index} title={event.details}>
                                     <span className="event-name">{event.name}</span>
-                                    <div className="event-details">{event.details}</div>
                                 </div>
                             ))}
                         </div>

--- a/lovecanberra-frontend/src/pages/homepage/homepage.css
+++ b/lovecanberra-frontend/src/pages/homepage/homepage.css
@@ -48,24 +48,7 @@
 }
 
 .event {
-    position: relative;
     margin: 0.5rem 0;
     cursor: pointer;
-}
-
-.event-details {
-    display: none;
-    position: absolute;
-    top: 100%;
-    left: 0;
-    background: white;
-    border: 1px solid #ccc;
-    padding: 0.5rem;
-    white-space: nowrap;
-    z-index: 1;
-}
-
-.event:hover .event-details {
-    display: block;
 }
 


### PR DESCRIPTION
## Summary
- replace custom hover details with browser tooltip for events to avoid scrolling
- remove unused CSS for previous hover implementation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68987f4cb11c83249880f50e4a165672