### PR TITLE
feat: add dark mode styling responsive to system preference

### DIFF
--- a/lovecanberra-frontend/src/index.css
+++ b/lovecanberra-frontend/src/index.css
@@ -4,8 +4,8 @@
   font-weight: 400;
 
   color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  color: #213547;
+  background-color: #ffffff;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -19,7 +19,7 @@ a {
   text-decoration: inherit;
 }
 a:hover {
-  color: #535bf2;
+  color: #747bff;
 }
 
 body {
@@ -42,7 +42,7 @@ button {
   font-size: 1em;
   font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
+  background-color: #f9f9f9;
   cursor: pointer;
   transition: border-color 0.25s;
 }
@@ -54,15 +54,15 @@ button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
 }
 
-@media (prefers-color-scheme: light) {
+@media (prefers-color-scheme: dark) {
   :root {
-    color: #213547;
-    background-color: #ffffff;
+    color: rgba(255, 255, 255, 0.87);
+    background-color: #242424;
   }
   a:hover {
-    color: #747bff;
+    color: #535bf2;
   }
   button {
-    background-color: #f9f9f9;
+    background-color: #1a1a1a;
   }
 }

--- a/lovecanberra-frontend/src/pages/homepage/homepage.css
+++ b/lovecanberra-frontend/src/pages/homepage/homepage.css
@@ -52,3 +52,9 @@
     cursor: pointer;
 }
 
+@media (prefers-color-scheme: dark) {
+    .day {
+        border-color: #555;
+    }
+}
+


### PR DESCRIPTION
## Summary
- invert base styles to light and apply dark theme via `prefers-color-scheme`
- tweak homepage schedule card borders for dark mode readability

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689887dbb9248324b4f55aee473fcbda