### PR TITLE
feat: switch homepage logo for light and dark modes

### DIFF
--- a/lovecanberra-frontend/src/pages/homepage/Homepage.tsx
+++ b/lovecanberra-frontend/src/pages/homepage/Homepage.tsx
@@ -1,6 +1,7 @@
 import { useState, type MouseEvent } from 'react';
 import './homepage.css';
-import titleImage from '../../assets/icons/most basic logo-black-text.png'; // need this to be modified so when it is dark mode, it uses the white text image instead, and the black text image when light mode
+import titleImageBlack from '../../assets/icons/most basic logo-black-text.png';
+import titleImageWhite from '../../assets/icons/most basic logo-white-text.png';
 
 interface Event {
     name: string;
@@ -95,7 +96,10 @@ export default function Homepage() {
         <>
             <Navbar />
             <main className="home-main">
-                <img src={titleImage} alt="title" className="title-image" />
+                <picture>
+                    <source srcSet={titleImageWhite} media="(prefers-color-scheme: dark)" />
+                    <img src={titleImageBlack} alt="title" className="title-image" />
+                </picture>
                 <h2 className="subheading">a city wide outreach</h2>
                 <div className="week-container">
                     {week.map(({ day, date, events }) => (

--- a/lovecanberra-frontend/src/pages/homepage/homepage.css
+++ b/lovecanberra-frontend/src/pages/homepage/homepage.css
@@ -63,15 +63,7 @@
     pointer-events: none;
 }
 
-@media (prefers-color-scheme: light) {
-    
-}
-
 @media (prefers-color-scheme: dark) {
-    .title-image {
-        /* TODO: modify this so the logo changes to the white text image instead */
-    }
-
     .event-tooltip {
         background-color: antiquewhite;
         color: black;


### PR DESCRIPTION
## Summary
- Use light and dark logo assets on the homepage via a `<picture>` element
- Clean up dark-mode CSS placeholder

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68988dce433883249652079d26a3bdb2