### PR TITLE
Align date numbers with day headers

### DIFF
--- a/lovecanberra-frontend/src/pages/homepage/homepage.css
+++ b/lovecanberra-frontend/src/pages/homepage/homepage.css
@@ -55,7 +55,8 @@
     text-align: left;
     align-content: left;
     overflow: hidden;
-
+    display: flex;
+    align-items: flex-start;
 }
 
 .day-of-week {
@@ -67,7 +68,8 @@
     font-family: "Reenie Beanie", cursive;
     font-weight: 900;
     font-size: 72px;
-    position: absolute;
+    line-height: 1;
+    margin-left: 0.2rem;
 }
 
 .event-collection {


### PR DESCRIPTION
## Summary
- Keep day headers and their date numbers on the same line using flex layout
- Remove absolute positioning and tweak spacing so dates sit neatly beside weekday text

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898bb6675408324b1f5909d8366500d